### PR TITLE
Fixed verbosity

### DIFF
--- a/tasks/cwebp.js
+++ b/tasks/cwebp.js
@@ -37,7 +37,7 @@ module.exports = grunt => {
           grunt.warn(error);
           next(error);
         } else {
-          grunt.log.writeln(chalk.green('✔ ') + src + ' was converted to ' + chalk.green(dest));
+          grunt.verbose.writeln(chalk.green('✔ ') + src + ' was converted to ' + chalk.green(dest));
           next();
         }
       });


### PR DESCRIPTION
Added `grunt.verbose` instead of `grunt.log` to report detailed file list only if `--verbose` flag is specified.